### PR TITLE
Centrally load dapreview.js

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -15,11 +15,6 @@ import {
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
-(async function daPreview() {
-  const { searchParams } = new URL(window.location.href);
-  if (searchParams.get('dapreview') === 'on') import('./dapreview.js');
-}());
-
 /**
  * Builds hero block and prepends to main in a new section.
  * @param {Element} main The container element
@@ -138,3 +133,12 @@ export async function loadPage() {
 }
 
 loadPage();
+
+// Side-effects
+(async function daPreview() {
+  const { searchParams } = new URL(window.location.href);
+  if (searchParams.get('dapreview') === 'on') {
+    const { default: livePreview } = await import('https://da.live/scripts/dapreview.js');
+    livePreview(loadPage);
+  }
+}());


### PR DESCRIPTION
Centrally load `dapreview.js` from da.live so the project can receive automatic updates to enhance live preview.